### PR TITLE
Версия 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 ###################################################################################################
 
 cmake_minimum_required(VERSION 3.8.2)
-project(Burst VERSION 2.0.0 LANGUAGES CXX)
+project(Burst VERSION 3.0.0 LANGUAGES CXX)
 
 get_directory_property(IS_SUBPROJECT PARENT_DIRECTORY)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Burst
 
 То, чего нет в Бусте.
 
-![Статус сборки под Linux](https://github.com/izvolov/burst/workflows/Linux/badge.svg) ![Статус сборки под macOS](https://github.com/izvolov/burst/workflows/macOS/badge.svg) [![Покрытие кода тестами](https://codecov.io/gh/izvolov/burst/branch/master/graph/badge.svg)](https://codecov.io/gh/izvolov/burst) [![Качество кода](https://api.codacy.com/project/badge/Grade/ddaf89951f3245b685a08e19e8f274d8)](https://www.codacy.com/app/izvolov/burst) [![Попробовать онлайн на Wandbox.org](https://img.shields.io/badge/try-online-blue.svg)](https://wandbox.org/permlink/hJj41x0T9m1P5rkT)
+![Статус сборки под Linux](https://github.com/izvolov/burst/workflows/Linux/badge.svg) ![Статус сборки под macOS](https://github.com/izvolov/burst/workflows/macOS/badge.svg) [![Покрытие кода тестами](https://codecov.io/gh/izvolov/burst/branch/master/graph/badge.svg)](https://codecov.io/gh/izvolov/burst) [![Качество кода](https://api.codacy.com/project/badge/Grade/ddaf89951f3245b685a08e19e8f274d8)](https://www.codacy.com/app/izvolov/burst) [![Попробовать онлайн на Wandbox.org](https://img.shields.io/badge/try-online-blue.svg)](https://wandbox.org/permlink/VO7XR4gg8HfOVkDF)
 
 О проекте
 ---------


### PR DESCRIPTION
#133
#135
#137
#139

Несовместимые изменения:

- `burst::take_n` берёт не ровно `n` элементов, а не более `n` элементов.

Новое:

- `burst::take_exactly`. Адаптор для откусывания ровно `n` элементов диапазона;
- `burst::take_at_most`. Синоним `burst::take_n`. Адаптор для откусывание не более `n` элементов диапазона;
-  `burst::to_vector`, `burst::to_deque`, `burst::to_list`, `burst::to_forward_list`, `burst::to_set`. Адапторы для создания диапазонов на основе семейства функций `burst::make_<container>`.

Изменения:
- Итератор слияния больше не требует однонаправленности от сливаемых диапазонов, им достаточно быть однопроходными.

Прочее:
- Небольшие улучшения производительности при конструировании контейнеров (семейство `burst::make_<container>`);
- Улучшение совместимости с новыми стандартами.
