### PR TITLE
doctest обновлён до версии 2.4.11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-12, macos-13, macos-14]
         build_type: ["Debug", "Release"]
 
     runs-on: ${{matrix.os}}

--- a/cmake/doctest.cmake
+++ b/cmake/doctest.cmake
@@ -1,4 +1,4 @@
-set(BURST_DOCTEST_VERSION 2.3.4)
+set(BURST_DOCTEST_VERSION 2.4.11)
 set(BURST_DOCTEST_REPOSITORY https://github.com/doctest/doctest.git)
 
 find_package(doctest ${BURST_DOCTEST_VERSION})
@@ -14,7 +14,7 @@ else()
         GIT_REPOSITORY
             ${BURST_DOCTEST_REPOSITORY}
         GIT_TAG
-            ${BURST_DOCTEST_VERSION}
+            v${BURST_DOCTEST_VERSION}
     )
     FetchContent_MakeAvailable(doctest)
 endif()


### PR DESCRIPTION
Также обновлены версии макоси в CI, т.к. старые уже неактуальны.