### PR TITLE
Область действия сужена до арифметических типов

### DIFF
--- a/include/burst/integer/detail/to_ordered_integral.hpp
+++ b/include/burst/integer/detail/to_ordered_integral.hpp
@@ -50,7 +50,7 @@ namespace burst
             ->
                 std::enable_if_t
                 <
-                    std::is_floating_point<Floating>::value,
+                    std::numeric_limits<Floating>::is_iec559,
                     unsigned_integer_of_size_t<sizeof(Floating)>
                 >
         {
@@ -62,19 +62,6 @@ namespace burst
             const auto u = bit_cast<integral_type>(f);
 
             return static_cast<integral_type>((u & sign_bit_mask) ? ~u : u ^ sign_bit_mask);
-        }
-
-        template <typename Enum>
-        constexpr auto to_ordered_integral_impl (Enum e)
-            -> std::enable_if_t<std::is_enum<Enum>::value, std::underlying_type_t<Enum>>
-        {
-            return static_cast<std::underlying_type_t<Enum>>(e);
-        }
-
-        template <typename Pointer>
-        constexpr auto to_ordered_integral_impl (Pointer * pointer)
-        {
-            return bit_cast<unsigned_integer_of_size_t<sizeof(Pointer *)>>(pointer);
         }
     } // namespace detail
 } // namespace burst

--- a/include/burst/integer/detail/to_ordered_integral.hpp
+++ b/include/burst/integer/detail/to_ordered_integral.hpp
@@ -63,6 +63,36 @@ namespace burst
 
             return static_cast<integral_type>((u & sign_bit_mask) ? ~u : u ^ sign_bit_mask);
         }
+
+        /*!
+            \brief
+                Перегрузка для `long double` запрещена
+
+            \details
+                `long double` сильно различается в зависимости от платформы и компилятора,
+                и определить его битность, чтобы привести к упорядоченному целому, практически
+                невозможно.
+
+                `numeric_limits<long double>::is_iec559` может быть истинно не только для
+                128-битных `long double`, но и для 80-битных. При этом фактический размер
+                80-битного `long double` (то, что возвращает `sizeof`) может быть и 10, и 12, и 16.
+                "Пустые биты", т.е. сверх используемых 80-ти, могут быть заполнены произвольными
+                данными.
+                Определить реальную битность можно только эвристически, например, найдя знаковый бит
+                по формуле:
+
+                \code{.cpp}
+                std::countr_zero
+                (
+                    std::bitcast<uint128_t>(-std::numeric_limits<F>::infinity()) ^
+                    std::bitcast<uint128_t>( std::numeric_limits<F>::infinity())
+                );
+                \endcode
+
+                Но даже если правильно определить битность, то на текущий момент (29.03.2025)
+                `std::bit_cast<uint128_t>(long double)` не является `constexpr`.
+         */
+        inline constexpr auto to_ordered_integral_impl (long double) = delete;
     } // namespace detail
 } // namespace burst
 

--- a/include/burst/integer/to_ordered_integral.hpp
+++ b/include/burst/integer/to_ordered_integral.hpp
@@ -3,26 +3,34 @@
 
 #include <burst/integer/detail/to_ordered_integral.hpp>
 
+#include <type_traits>
+#include <limits>
+
 namespace burst
 {
     /*!
         \brief
-            Представить скалярный тип в виде упорядоченного целого
+            Представить арифметический тип в виде упорядоченного целого
 
         \details
-            Функция определена для упорядоченных скалярных типов, то есть для целых чисел,
-            чисел с плавающей запятой, указателей и перечислений.
+            Функция определена для упорядоченных арифметических типов, то есть для целых чисел и
+            чисел с плавающей запятой.
 
             Возвращает такое целочисленное представление, что:
                 ∀ x, y: x < y => to_ordered_integral(x) < to_ordered_integral(y),
-            где `x`, `y` — значения типа `Scalar`.
+            где `x`, `y` — значения типа `Arithmetic`.
      */
     struct to_ordered_integral_fn
     {
-        template <typename Scalar>
-        constexpr auto operator () (Scalar value) const
+        template <typename Arithmetic>
+        constexpr auto operator () (Arithmetic value) const
         {
-            static_assert(std::is_scalar<Scalar>::value, "Значение должно быть скаляром");
+            static_assert
+            (
+                std::is_integral<Arithmetic>::value || std::numeric_limits<Arithmetic>::is_iec559,
+                "Требуется целое число или число с плавающей запятой, "
+                "соответствующее стандарту IEC 559 (IEEE 754)"
+            );
             return detail::to_ordered_integral_impl(value);
         }
     };

--- a/test/burst/integer/to_ordered_integral.cpp
+++ b/test/burst/integer/to_ordered_integral.cpp
@@ -49,35 +49,6 @@ TEST_SUITE("to_ordered_integral")
         check(max, pos_inf);
     }
 
-    TEST_CASE_TEMPLATE("Отношение порядка на образах указателей соответствует отношению порядка "
-        "на самих указателях", pointee_type, int, const double)
-    {
-        const auto a = std::array<pointee_type, 10>{};
-        const auto first = a.data();
-        const auto last = first + a.size();
-
-        CHECK(burst::to_ordered_integral(first) < burst::to_ordered_integral(first + 1));
-        CHECK(burst::to_ordered_integral(first) < burst::to_ordered_integral(first + a.size() / 2));
-        CHECK(burst::to_ordered_integral(first) < burst::to_ordered_integral(last));
-        CHECK(burst::to_ordered_integral(first + 1) < burst::to_ordered_integral(last));
-        CHECK(burst::to_ordered_integral(first + a.size() / 2) < burst::to_ordered_integral(last));
-    }
-
-    TEST_CASE("Отношение порядка на образах перечислений соответствует отношению порядка "
-        "на самих перечислениях")
-    {
-        enum struct e
-        {
-            x = 2,
-            y = 1,
-            z = 0,
-        };
-
-        CHECK(burst::to_ordered_integral(e::z) < burst::to_ordered_integral(e::y));
-        CHECK(burst::to_ordered_integral(e::z) < burst::to_ordered_integral(e::x));
-        CHECK(burst::to_ordered_integral(e::y) < burst::to_ordered_integral(e::x));
-    }
-
     TEST_CASE_TEMPLATE("Для целых чисел тип результата равен исходному типу", integral_type,
         std::int8_t, std::uint8_t,
         std::int16_t, std::uint16_t,
@@ -93,8 +64,7 @@ TEST_SUITE("to_ordered_integral")
     }
 
     TEST_CASE_TEMPLATE("Для типов с плавающей запятой и указателей тип результата соответствует "
-        "целому числу такого же размера, как исходный тип", scalar_type,
-        float, double, int *, const char *)
+        "целому числу такого же размера, как исходный тип", scalar_type, float, double)
     {
         CHECK(std::is_same
         <
@@ -102,60 +72,5 @@ TEST_SUITE("to_ordered_integral")
             burst::unsigned_integer_of_size_t<sizeof(scalar_type)>
         >
         ::value);
-    }
-
-    TEST_CASE_TEMPLATE("Для перечислений тип результата равен типу базового для перечисления целого", base_type,
-        std::int8_t, std::uint8_t,
-        std::int16_t, std::uint16_t,
-        std::int32_t, std::uint32_t,
-        std::int64_t, std::uint64_t)
-    {
-        SUBCASE("в случае обыкновенного перечисления")
-        {
-            enum simple_enum: base_type
-            {
-                x,
-                y
-            };
-
-            CHECK(std::is_same
-            <
-                burst::invoke_result_t<burst::to_ordered_integral_fn, simple_enum>,
-                std::underlying_type_t<simple_enum>
-            >
-            ::value);
-        }
-
-        SUBCASE("в случае enum struct")
-        {
-            enum struct enum_struct: base_type
-            {
-                x,
-                y
-            };
-
-            CHECK(std::is_same
-            <
-                burst::invoke_result_t<burst::to_ordered_integral_fn, enum_struct>,
-                std::underlying_type_t<enum_struct>
-            >
-            ::value);
-        }
-
-        SUBCASE("в случае enum class")
-        {
-            enum class enum_class: base_type
-            {
-                x,
-                y
-            };
-
-            CHECK(std::is_same
-            <
-                burst::invoke_result_t<burst::to_ordered_integral_fn, enum_class>,
-                std::underlying_type_t<enum_class>
-            >
-            ::value);
-        }
     }
 }


### PR DESCRIPTION
- Для перечислений может быть определено пользовательское сравнение, поэтому для них нельзя использовать приведение к целым;
- Указатель не может быть приведён к целочисленному представлению в рамках `constexpr`-выражения.
- Кроме того, числа с плавающей запятой могут не соответствовать стандарту IEEE 754, поэтому для тех чисел, которые ему не соответствуют, данное преобразование может быть неприменимо.

#190 